### PR TITLE
Add boilerplate files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+This repository is being used for work in the W3C Web Machine Learning Community Group,
+governed by the [W3C Community License Agreement (CLA)](https://www.w3.org/community/about/agreements/cla/).
+To make substantive contributions, you must join the CG.
+
+If you are not the sole contributor to a contribution (pull request), please identify all
+contributors in the pull request comment.
+
+To add a contributor (other than yourself, that's automatic), mark them one per line as follows:
+
+```
++@github_username
+```
+
+If you added a contributor by mistake, you can remove them in a comment with:
+
+```
+-@github_username
+```
+
+If you are making a pull request on behalf of someone else but you had no part in designing the
+feature, you can remove yourself with the above syntax.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,2 @@
+All Reports in this Repository are licensed by Contributors
+under the [W3C Software and Document License](https://www.w3.org/copyright/software-license-2023/).


### PR DESCRIPTION
This adds the usual boilerplate files used by this CG per https://webmachinelearning.github.io/charter/#contrib

I have removed Specifications and Test Suites from the [baseline license](https://raw.githubusercontent.com/w3c/licenses/master/CG-LICENSE.md) adopted by this repo, because those deliverable types are not in scope of this repo. I've also updated the license reference to point to its latest 2023 version.

If the CG believes this exploration warrants new spec work in the future, such work will happen in a new dedicated repo, not in this repo.
